### PR TITLE
Updated the filter category to work with KSP 1.3

### DIFF
--- a/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
+++ b/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
@@ -21,7 +21,7 @@ namespace InfernalRobotics.Gui
 
         private void IRCustomFilter()
         {
-            const string FILTER_CATEGORY = "Filter by Function";
+            const string FILTER_CATEGORY = "Filter by function";
             const string CUSTOM_CATEGORY_NAME = "Robotic";
 
             //var texture_on = new Texture2D(36, 36, TextureFormat.RGBA32, false);


### PR DESCRIPTION
The "Filter by function" category name changed to have a lower case "f" in KSP 1.3, preventing the custom editor category from showing up. This updates IRCustomFilter to use the new name.

To make sure this isn't affected by the selected language I verified that the category still shows up if I change the language to Spanish.